### PR TITLE
Replace Fathom Analytics with GA4

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -35,8 +35,20 @@ export default {
       { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }
     ],
     script: [
-      { src: 'https://cdn.usefathom.com/script.js', 'data-site': 'JGSWCLYU', defer: true }
-    ]
+      { src: 'https://www.googletagmanager.com/gtag/js?id=G-LLY1T4DZX7', async: true },
+      {
+        hid: 'gtag-init',
+        innerHTML: `
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', 'G-LLY1T4DZX7');
+        `,
+        type: 'text/javascript',
+        charset: 'utf-8'
+      }
+    ],
+    __dangerouslyDisableSanitizers: ['script']
   },
 
   // Global CSS: https://go.nuxtjs.dev/config-css


### PR DESCRIPTION
## Summary
- Removes Fathom Analytics (`data-site=JGSWCLYU`) from the site `<head>`
- Adds Google Analytics 4 tag `G-LLY1T4DZX7` via `nuxt.config.js` `head.script[]`
- Adds `__dangerouslyDisableSanitizers: ['script']` so Nuxt 2 preserves the inline `gtag()` init snippet

## Why
Switch site measurement from Fathom to GA4 so traffic lives alongside the rest of the disclose.io analytics estate. GA4 property: `G-LLY1T4DZX7`.

## Test plan
- [ ] Merge triggers `.github/workflows/deploy.yml`
- [ ] After deploy, `curl -s https://policymaker.disclose.io/ | grep G-LLY1T4DZX7` returns the gtag loader tag
- [ ] Confirm Fathom script (`cdn.usefathom.com`) is no longer present in rendered HTML
- [ ] Visit the live site; verify a session appears in GA4 Realtime
- [ ] Browser devtools → Network filter `gtag/js` shows the loader, `collect?` requests fire on nav

## Notes
- Privacy posture regression: Fathom was cookieless; GA4 uses cookies and may need a consent UI for EU visitors — worth considering as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)