### PR TITLE
Fix GA4 download events + add lineage stamp to generated artifacts

### DIFF
--- a/components/DioTermPreview/DioTermPreview.vue
+++ b/components/DioTermPreview/DioTermPreview.vue
@@ -86,8 +86,8 @@ export default Vue.extend({
 
             const link = document.createElement('a')
 
-            // construct download blob
-            let fileBlob = new Blob([policyText], {type: download.type})
+            // construct download blob (stamped for template-lineage detection)
+            let fileBlob = new Blob([vm.stamp(policyText, download.type)], {type: download.type})
             link.href = URL.createObjectURL(fileBlob)
             link.download = download.filename
             link.click()
@@ -100,6 +100,19 @@ export default Vue.extend({
             }
         },
 
+        // Version stamp: a stable fingerprint phrase + date + unique id, appended as a
+        // format-appropriate comment. Enables lineage detection of published artifacts
+        // (code/web search + diosts scans). Client-side: uniqueness, not cryptographic signing.
+        stamp(policyText: string, mimeType: string): string {
+            const date = new Date().toISOString().slice(0, 10)
+            const id = Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 8)
+            const label = `Generated with policymaker.disclose.io (dioterms) | ${date} | id:${id}`
+            if (mimeType === 'text/plain') {
+                return `${policyText.replace(/\s+$/, '')}\n\n# ${label}\n`
+            }
+            return `${policyText.replace(/\s+$/, '')}\n\n<!-- ${label} -->\n`
+        },
+
         track(download: any): void {
             const vm = this as any
 
@@ -109,7 +122,19 @@ export default Vue.extend({
                 event.eventLabel = [vm.localLanguage, event.eventLabel].join('_')
             }
 
-            vm.$ga.event(event)
+            // GA4 (gtag.js) — the previous vm.$ga.event() targeted the removed
+            // vue-analytics/UA plugin, so download events were silently lost after #15.
+            const gtag = (window as any).gtag
+            if (typeof gtag === 'function') {
+                const name = `${event.eventCategory}_${event.eventAction}`
+                    .replace(/[^a-zA-Z0-9_]/g, '_').slice(0, 40)
+                gtag('event', name, {
+                    event_category: event.eventCategory,
+                    event_label: event.eventLabel,
+                    artifact: event.eventCategory,
+                    format: (download.trackingEvent || {}).eventLabel
+                })
+            }
         }
     },
 


### PR DESCRIPTION
## What
- **Fixes silently-lost analytics:** `DioTermPreview.track()` still called `vm.$ga.event()` (the vue-analytics/UA API) after #15 swapped Fathom for GA4 — so no download event has reached analytics since. Now bridges to `gtag.js`: GA4-sanitized event names (`vdp_download`, `security_txt_download`, …) with `event_category` / `event_label` / `artifact` / `format` params. No-ops safely if gtag is absent.
- **Lineage stamp on generated artifacts:** downloads now end with a comment stamp — `Generated with policymaker.disclose.io (dioterms) | YYYY-MM-DD | id:<unique>` — `#`-comment for text/plain (valid in security.txt), HTML comment for markdown/HTML. Makes published artifacts detectable via code/web search and diosts scans. Client-side, so this is uniqueness, not cryptographic signing; a signed stamp would need a small server component (future work).

## Why
Top instrumentation priority in the disclose.io metrics doctrine: policymaker's north-star metric is *generated policies detected live in the wild* — that needs (a) working generation events and (b) a detectable fingerprint on artifacts.

## Testing
Static review + grep (no $ga references remain); CI build validates. One functional check worth doing on preview: click each download button, confirm events land in GA4 realtime (G-LLY1T4DZX7) and files end with the stamp.