### PR TITLE
feat(seo/aio): SoftwareApplication JSON-LD + llms.txt/sitemap/robots

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -46,6 +46,24 @@ export default {
         `,
         type: 'text/javascript',
         charset: 'utf-8'
+      },
+      {
+        hid: 'ld-json',
+        type: 'application/ld+json',
+        json: {
+          '@context': 'https://schema.org',
+          '@type': 'SoftwareApplication',
+          name: 'Policymaker',
+          alternateName: 'disclose.io Policymaker',
+          url: 'https://policymaker.disclose.io/',
+          description: 'Free, open-source generator for vulnerability disclosure policies, security.txt files, and DNS Security TXT records.',
+          applicationCategory: 'SecurityApplication',
+          operatingSystem: 'Web',
+          offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+          isAccessibleForFree: true,
+          license: 'https://github.com/disclose/policymaker/blob/main/LICENSE.md',
+          publisher: { '@type': 'Organization', name: 'disclose.io', url: 'https://disclose.io/' }
+        }
       }
     ],
     __dangerouslyDisableSanitizers: ['script']

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -1,0 +1,20 @@
+# Policymaker (disclose.io)
+
+> A free, open-source web tool that generates vulnerability disclosure policies, security.txt files, and DNS Security TXT records from a short guided form.
+
+Canonical: https://policymaker.disclose.io/
+Publisher: disclose.io
+License: open source (see https://github.com/disclose/policymaker)
+
+## What it does
+- Generates a customized **vulnerability disclosure policy (VDP)** / bug bounty policy from the disclose.io framework (dioterms).
+- Produces a **security.txt** file (RFC 9116) with your security contact and policy URLs.
+- Produces a **DNS Security TXT** (`_security` TXT) record for DNS-based security-contact discovery.
+
+## How to use
+Open the site, answer the guided questions (scope, safe harbor, contact, disclosure timelines), and copy or download the generated policy, security.txt, and DNS record.
+
+## Related disclose.io properties
+- The terms it builds on: https://disclose.io/framework/ and https://history.disclose.io/ (their provenance)
+- DNS Security TXT standard: https://dnssecuritytxt.org/
+- Security-contact lookup: https://lookup.disclose.io/

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,27 @@
+# Policymaker — disclose.io VDP / security.txt / DNS Security TXT generator
+User-agent: *
+Allow: /
+
+# AI crawlers welcome
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+Sitemap: https://policymaker.disclose.io/sitemap.xml

--- a/static/sitemap.xml
+++ b/static/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://policymaker.disclose.io/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
policymaker.disclose.io had **no structured data** and no llms.txt/sitemap (found in a disclose.io ecosystem SEO/AIO audit). og/Twitter meta and GA4 were already present.

This adds:
- **SoftwareApplication JSON-LD** in the Nuxt head (free security tool; publisher disclose.io).
- **static/llms.txt** — machine-readable description for AI crawlers.
- **static/sitemap.xml** + **static/robots.txt** (AI crawlers allowed + sitemap ref).

Docs/config only; no app logic. `node --check nuxt.config.js` passes.