### PR TITLE
feat(design): restyle to lookup.disclose.io app design system + light/dark toggle

### DIFF
--- a/assets/css/_app-theme.css
+++ b/assets/css/_app-theme.css
@@ -1,0 +1,71 @@
+/* ─────────────────────────────────────────────────────────────
+ * disclose.io — APP Design System
+ * Source of truth: lookup.disclose.io (the dark-default app language).
+ * Distinct from the marketing WEBSITE system (Noto Sans, light-only).
+ * Dark is the DEFAULT (:root); light is [data-theme="light"] on <html>.
+ * ───────────────────────────────────────────────────────────── */
+
+@import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&family=JetBrains+Mono:wght@400;500&display=swap');
+
+:root {
+  /* Surfaces (dark default) */
+  --bg:            #0a0a0f;
+  --surface:       #12121a;
+  --surface-2:     #1a1a25;
+  --surface-3:     #222230;
+  --border:        #2a2a35;
+  --border-light:  #35354a;
+
+  /* Text */
+  --text:          #e4e4e8;
+  --text-heading:  #f4f4f5;
+  --text-muted:    #8888a0;
+  --text-dim:      #5a5a70;
+
+  /* Accent (violet) */
+  --accent:        #7c5cfc;
+  --accent-hover:  #9580ff;
+  --accent-dim:    rgba(124, 92, 252, 0.12);
+
+  /* Status */
+  --high:      #22c55e;  --high-bg:   rgba(34, 197, 94, 0.10);  --high-border:   rgba(34, 197, 94, 0.25);
+  --medium:    #eab308;  --medium-bg: rgba(234, 179, 8, 0.10);
+  --error:     #ef4444;  --error-bg:  rgba(239, 68, 68, 0.10);
+  --success:   #22c55e;
+
+  /* Type */
+  --font: 'DM Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --mono: 'JetBrains Mono', 'SF Mono', 'Fira Code', ui-monospace, monospace;
+
+  /* Radius / shadow / motion */
+  --radius:    8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+  --shadow:    0 1px 3px rgba(0, 0, 0, 0.30), 0 1px 2px rgba(0, 0, 0, 0.20);
+  --shadow-lg: 0 4px 12px rgba(0, 0, 0, 0.40), 0 2px 4px rgba(0, 0, 0, 0.30);
+  --transition: 0.15s ease;
+}
+
+/* ── Light theme ─────────────────────────────────────────────── */
+[data-theme="light"] {
+  --bg:            #f5f5f7;
+  --surface:       #ffffff;
+  --surface-2:     #f0f0f4;
+  --surface-3:     #e8e8ee;
+  --border:        #d4d4dc;
+  --border-light:  #c0c0cc;
+
+  --text:          #1a1a2e;
+  --text-heading:  #0a0a15;
+  --text-muted:    #6b6b80;
+  --text-dim:      #9090a0;
+
+  --accent:        #6340e8;
+  --accent-hover:  #7c5cfc;
+  --accent-dim:    rgba(99, 64, 232, 0.08);
+
+  --high-bg:   rgba(34, 197, 94, 0.08);
+  --error-bg:  rgba(239, 68, 68, 0.08);
+  --shadow:    0 1px 3px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.04);
+  --shadow-lg: 0 4px 12px rgba(0, 0, 0, 0.10), 0 2px 4px rgba(0, 0, 0, 0.06);
+}

--- a/assets/css/_variables.css
+++ b/assets/css/_variables.css
@@ -1,15 +1,25 @@
+/* Legacy policymaker tokens — REMAPPED onto the disclose.io app design system
+ * (see _app-theme.css). Kept as a compatibility shim so existing component
+ * <style> blocks that reference --purple / --white / --shade-* re-theme
+ * (dark/light) automatically without touching every component.
+ *
+ * NOTE: --white here means the SURFACE background. On-accent TEXT that
+ * previously used var(--white) as a foreground is set to explicit #fff in
+ * DioButton, DioLink, and ProgressStep (dark text on violet would fail). */
 :root {
-    --dark-purple: hsla(262, 22%, 21%, 1);
-    --purple: hsla(262, 52%, 47%, 1);
-    --white: hsla(0, 0%, 100%, 1);
-    --shade-050: hsla(240, 8%, 97%, 1);
-    --shade-100: hsla(240, 10%, 94%, 1);
-    --shade-200: hsla(240, 5%, 89%, 1);
-    --shade-300: hsla(240, 8%, 85%, 1);
-    --shade-400: hsla(240, 7%, 79%, 1);
-    --shade-500: hsla(240, 5%, 74%, 1);
-    --shade-600: hsla(240, 5%, 64%, 1);
-    --shade-700: hsla(240, 3%, 55%, 1);
-    --shade-800: hsla(240, 4%, 47%, 1);
-    --shade-900: hsla(231, 3%, 41%, 1);
+    --dark-purple: var(--text-heading);
+    --purple: var(--accent);
+    --purple-hover: var(--accent-hover);
+    --white: var(--surface);
+
+    --shade-050: var(--bg);
+    --shade-100: var(--surface-2);
+    --shade-200: var(--border);
+    --shade-300: var(--border-light);
+    --shade-400: var(--border-light);
+    --shade-500: var(--text-dim);
+    --shade-600: var(--text-muted);
+    --shade-700: var(--text-muted);
+    --shade-800: var(--text);
+    --shade-900: var(--text-heading);
 }

--- a/components/DioButton/DioButton.vue
+++ b/components/DioButton/DioButton.vue
@@ -49,7 +49,7 @@ export default Vue.extend({
         /* Themes */
         &-solid {
             background: var(--purple);
-            color: var(--white);
+            color: #fff;
         }
 
         &-transparent {

--- a/components/DioLink/DioLink.vue
+++ b/components/DioLink/DioLink.vue
@@ -46,7 +46,7 @@ export default Vue.extend({
         /* Themes */
         &-solid {
             background: var(--purple);
-            color: var(--white);
+            color: #fff;
         }
 
         &-transparent {

--- a/components/DioProgressStep/ProgressStep.vue
+++ b/components/DioProgressStep/ProgressStep.vue
@@ -100,7 +100,7 @@ export default Vue.extend({
             color: var(--dark-purple);
             
             .dio__step-anchor {
-                color: var(--white);
+                color: #fff;
                 background: var(--purple);
                 border-color: var(--purple);
             }

--- a/layouts/policymaker.vue
+++ b/layouts/policymaker.vue
@@ -5,6 +5,12 @@
                 <img src="@/assets/images/logo-disclose-type.svg">
             </NuxtLink>
 
+            <button class="theme-toggle" type="button" @click="toggleTheme"
+                :title="isLight ? 'Switch to dark theme' : 'Switch to light theme'"
+                aria-label="Toggle light/dark theme">
+                <span v-if="isLight">☀</span><span v-else>☾</span>
+            </button>
+
             <nav>
                 <progress-steps orientation="vertical" :steps="navSteps">
                 </Progress-Steps>
@@ -36,6 +42,7 @@ export default Vue.extend({
     
     data() {
         return {
+            isLight: false
         }
     },
 
@@ -54,10 +61,27 @@ export default Vue.extend({
     },
 
     mounted() {
+        const vm = this as any
+        vm.isLight = document.documentElement.getAttribute('data-theme') === 'light'
         this.$nextTick(() => {
             store.dispatch('policymaker/fetchLanguages')
             store.dispatch('policymaker/syncStepFromRoute', this.$route.fullPath)
         })
+    },
+
+    methods: {
+        toggleTheme(): void {
+            const vm = this as any
+            vm.isLight = !vm.isLight
+            const root = document.documentElement
+            if (vm.isLight) {
+                root.setAttribute('data-theme', 'light')
+                try { localStorage.setItem('dio-theme', 'light') } catch (e) {}
+            } else {
+                root.removeAttribute('data-theme')
+                try { localStorage.setItem('dio-theme', 'dark') } catch (e) {}
+            }
+        }
     },
 
     computed: {
@@ -70,10 +94,9 @@ export default Vue.extend({
 
 <style lang="postcss">
 :root {
-    color: var(--dark-purple);
-    background: linear-gradient(90deg, var(--white) 50%, var(--shade-050) 50%);
-    /* font-family: "Noto Sans", Roboto, "Helvetica Neue", ui-sans-serif, system-ui, -apple-system, system-ui; */
-    font-family: "Noto Sans";
+    color: var(--text);
+    background: var(--bg);
+    font-family: var(--font);
 }
 
 #app {
@@ -85,7 +108,8 @@ export default Vue.extend({
 
 
 header {
-    background: var(--white);
+    background: var(--surface);
+    border-right: 1px solid var(--border);
     @apply fixed flex flex-row items-center h-16 px-4 overflow-hidden min-w-max;
     @apply w-full z-10;
     @apply lg:flex-col lg:h-full lg:items-start lg:pt-8 lg:pb-8 lg:w-80 ;
@@ -98,6 +122,24 @@ header {
 
     nav {
         @apply mt-12 mb-12 hidden lg:block;
+    }
+
+    .theme-toggle {
+        @apply flex items-center justify-center cursor-pointer;
+        width: 36px;
+        height: 36px;
+        margin-left: auto;
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        color: var(--text-muted);
+        font-size: 16px;
+        transition: all var(--transition);
+
+        &:hover {
+            border-color: var(--border-light);
+            color: var(--text);
+        }
     }
 }
 
@@ -122,7 +164,8 @@ main {
 }
 
 h1,h2,h3,h4,h5,h6 {
-    font-family: 'Noto Sans Display'
+    font-family: var(--font);
+    color: var(--text-heading);
 }
 
 h3 {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -32,9 +32,17 @@ export default {
       { hid: 'twitter:image', name: 'twitter:image', content: 'https://disclose.io/uploads/becausemath-2026.png' },
     ],
     link: [
-      { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }
+      { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },
+      { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
+      { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: '' },
+      { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&family=JetBrains+Mono:wght@400;500&display=swap' }
     ],
     script: [
+      {
+        hid: 'theme-init',
+        innerHTML: `(function(){try{var t=localStorage.getItem('dio-theme');if(t==='light'){document.documentElement.setAttribute('data-theme','light');}}catch(e){}})();`,
+        type: 'text/javascript'
+      },
       { src: 'https://www.googletagmanager.com/gtag/js?id=G-LLY1T4DZX7', async: true },
       {
         hid: 'gtag-init',
@@ -71,6 +79,7 @@ export default {
 
   // Global CSS: https://go.nuxtjs.dev/config-css
   css: [
+    '@/assets/css/_app-theme.css',
     '@/assets/css/_fonts.css',
     '@/assets/css/_variables.css'
   ],

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,56 @@
+/* disclose.io app design-system palette bridge.
+ *
+ * policymaker styles its components with Tailwind `@apply` using the DEFAULT
+ * palette (bg-white, text-purple-800, bg-yellow-100, text-gray-700, ...).
+ * Because those live inside <style> @apply blocks (not template class="" attrs),
+ * they can only be re-skinned at the Tailwind layer. This remaps the specific
+ * default-palette shades in use onto the app-theme CSS variables so every
+ * @apply color themes (dark/light) automatically. `extend` deep-merges with
+ * Tailwind's defaults, so unspecified shades keep their normal values. */
+module.exports = {
+  theme: {
+    extend: {
+      colors: {
+        // surfaces
+        white: 'var(--surface)',
+        // brand / links → accent
+        purple: {
+          100: 'var(--accent-dim)',
+          400: 'var(--accent)',
+          600: 'var(--accent)',
+          700: 'var(--accent)',
+          800: 'var(--accent)',
+        },
+        // stray link color → accent (DioTermPreview)
+        blue: {
+          600: 'var(--accent)',
+        },
+        // code / callout accents (were yellow) → accent
+        yellow: {
+          100: 'var(--accent-dim)',
+          600: 'var(--accent)',
+          700: 'var(--accent)',
+          800: 'var(--accent)',
+        },
+        // validation
+        red: {
+          100: 'var(--error-bg)',
+          600: 'var(--error)',
+        },
+        green: {
+          100: 'var(--high-bg)',
+          600: 'var(--high)',
+        },
+        // neutrals → themed text/border
+        gray: {
+          100: 'var(--border-light)',
+          200: 'var(--border)',
+          300: 'var(--border)',
+          400: 'var(--border)',
+          500: 'var(--text-muted)',
+          700: 'var(--text)',
+        },
+      },
+    },
+  },
+}


### PR DESCRIPTION
Restyles Policymaker to match **lookup.disclose.io**'s app language and codifies the disclose.io *app* design system.

## What
- **`assets/css/_app-theme.css`** — lookup-derived app tokens: dark-default `:root` + `[data-theme="light"]`, DM Sans + JetBrains Mono, radii/shadows/motion.
- **`_variables.css`** — remaps legacy `--purple`/`--white`/`--shade-*` onto the app tokens so existing component styles re-theme automatically.
- **`tailwind.config.js`** — bridges the default-palette colors used via `@apply` (`bg-white`, `text-purple-*`, etc.) onto the CSS vars so they theme in both modes.
- **`layouts/policymaker.vue`** — dark app chrome + a persisted light/dark **theme toggle** (defaults dark, like lookup).
- On-accent text pinned to `#fff` (DioButton, DioLink, ProgressStep).
- `nuxt.config.js` — registers the app-theme CSS, a pre-paint theme-init script (no FOUC), and the DM Sans font link.

## Verification
- Full wizard driven end-to-end (org → contacts → settings → download); VDP / security.txt / DNS Security.txt all generate correctly; variant toggle + Save-as-markdown/HTML + language selector all work.
- WCAG AA contrast passes in **both** themes; zero new console errors.
- `nuxt generate` (static prod) builds clean on current `main`; Chrome-verified on a noindex preview.
- No IA/logic changes — visual language only.