### PR TITLE
feat(design): light mode default, dark as opt-in toggle

### DIFF
--- a/assets/css/_app-theme.css
+++ b/assets/css/_app-theme.css
@@ -1,36 +1,37 @@
 /* ─────────────────────────────────────────────────────────────
- * disclose.io — APP Design System
- * Source of truth: lookup.disclose.io (the dark-default app language).
- * Distinct from the marketing WEBSITE system (Noto Sans, light-only).
- * Dark is the DEFAULT (:root); light is [data-theme="light"] on <html>.
+ * disclose.io — APP Design System (Policymaker: LIGHT-default)
+ * Tokens derived from lookup.disclose.io's app language.
+ * Policymaker defaults to LIGHT (:root); dark is opt-in via
+ * [data-theme="dark"] on <html>. (lookup itself is dark-default;
+ * this app deliberately leads with light.)
  * ───────────────────────────────────────────────────────────── */
 
 @import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&family=JetBrains+Mono:wght@400;500&display=swap');
 
 :root {
-  /* Surfaces (dark default) */
-  --bg:            #0a0a0f;
-  --surface:       #12121a;
-  --surface-2:     #1a1a25;
-  --surface-3:     #222230;
-  --border:        #2a2a35;
-  --border-light:  #35354a;
+  /* Surfaces (light default) */
+  --bg:            #f5f5f7;
+  --surface:       #ffffff;
+  --surface-2:     #f0f0f4;
+  --surface-3:     #e8e8ee;
+  --border:        #d4d4dc;
+  --border-light:  #c0c0cc;
 
   /* Text */
-  --text:          #e4e4e8;
-  --text-heading:  #f4f4f5;
-  --text-muted:    #8888a0;
-  --text-dim:      #5a5a70;
+  --text:          #1a1a2e;
+  --text-heading:  #0a0a15;
+  --text-muted:    #6b6b80;
+  --text-dim:      #9090a0;
 
   /* Accent (violet) */
-  --accent:        #7c5cfc;
-  --accent-hover:  #9580ff;
-  --accent-dim:    rgba(124, 92, 252, 0.12);
+  --accent:        #6340e8;
+  --accent-hover:  #7c5cfc;
+  --accent-dim:    rgba(99, 64, 232, 0.08);
 
   /* Status */
-  --high:      #22c55e;  --high-bg:   rgba(34, 197, 94, 0.10);  --high-border:   rgba(34, 197, 94, 0.25);
-  --medium:    #eab308;  --medium-bg: rgba(234, 179, 8, 0.10);
-  --error:     #ef4444;  --error-bg:  rgba(239, 68, 68, 0.10);
+  --high:      #22c55e;  --high-bg:   rgba(34, 197, 94, 0.08);  --high-border:   rgba(34, 197, 94, 0.30);
+  --medium:    #eab308;  --medium-bg: rgba(234, 179, 8, 0.08);
+  --error:     #ef4444;  --error-bg:  rgba(239, 68, 68, 0.08);
   --success:   #22c55e;
 
   /* Type */
@@ -41,31 +42,33 @@
   --radius:    8px;
   --radius-lg: 12px;
   --radius-xl: 16px;
-  --shadow:    0 1px 3px rgba(0, 0, 0, 0.30), 0 1px 2px rgba(0, 0, 0, 0.20);
-  --shadow-lg: 0 4px 12px rgba(0, 0, 0, 0.40), 0 2px 4px rgba(0, 0, 0, 0.30);
+  --shadow:    0 1px 3px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.04);
+  --shadow-lg: 0 4px 12px rgba(0, 0, 0, 0.10), 0 2px 4px rgba(0, 0, 0, 0.06);
   --transition: 0.15s ease;
 }
 
-/* ── Light theme ─────────────────────────────────────────────── */
-[data-theme="light"] {
-  --bg:            #f5f5f7;
-  --surface:       #ffffff;
-  --surface-2:     #f0f0f4;
-  --surface-3:     #e8e8ee;
-  --border:        #d4d4dc;
-  --border-light:  #c0c0cc;
+/* ── Dark theme (opt-in via toggle) ──────────────────────────── */
+[data-theme="dark"] {
+  --bg:            #0a0a0f;
+  --surface:       #12121a;
+  --surface-2:     #1a1a25;
+  --surface-3:     #222230;
+  --border:        #2a2a35;
+  --border-light:  #35354a;
 
-  --text:          #1a1a2e;
-  --text-heading:  #0a0a15;
-  --text-muted:    #6b6b80;
-  --text-dim:      #9090a0;
+  --text:          #e4e4e8;
+  --text-heading:  #f4f4f5;
+  --text-muted:    #8888a0;
+  --text-dim:      #5a5a70;
 
-  --accent:        #6340e8;
-  --accent-hover:  #7c5cfc;
-  --accent-dim:    rgba(99, 64, 232, 0.08);
+  --accent:        #7c5cfc;
+  --accent-hover:  #9580ff;
+  --accent-dim:    rgba(124, 92, 252, 0.12);
 
-  --high-bg:   rgba(34, 197, 94, 0.08);
-  --error-bg:  rgba(239, 68, 68, 0.08);
-  --shadow:    0 1px 3px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.04);
-  --shadow-lg: 0 4px 12px rgba(0, 0, 0, 0.10), 0 2px 4px rgba(0, 0, 0, 0.06);
+  --high-bg:     rgba(34, 197, 94, 0.10);
+  --high-border: rgba(34, 197, 94, 0.25);
+  --medium-bg:   rgba(234, 179, 8, 0.10);
+  --error-bg:    rgba(239, 68, 68, 0.10);
+  --shadow:      0 1px 3px rgba(0, 0, 0, 0.30), 0 1px 2px rgba(0, 0, 0, 0.20);
+  --shadow-lg:   0 4px 12px rgba(0, 0, 0, 0.40), 0 2px 4px rgba(0, 0, 0, 0.30);
 }

--- a/layouts/policymaker.vue
+++ b/layouts/policymaker.vue
@@ -62,7 +62,7 @@ export default Vue.extend({
 
     mounted() {
         const vm = this as any
-        vm.isLight = document.documentElement.getAttribute('data-theme') === 'light'
+        vm.isLight = document.documentElement.getAttribute('data-theme') !== 'dark'
         this.$nextTick(() => {
             store.dispatch('policymaker/fetchLanguages')
             store.dispatch('policymaker/syncStepFromRoute', this.$route.fullPath)
@@ -75,10 +75,10 @@ export default Vue.extend({
             vm.isLight = !vm.isLight
             const root = document.documentElement
             if (vm.isLight) {
-                root.setAttribute('data-theme', 'light')
+                root.removeAttribute('data-theme')
                 try { localStorage.setItem('dio-theme', 'light') } catch (e) {}
             } else {
-                root.removeAttribute('data-theme')
+                root.setAttribute('data-theme', 'dark')
                 try { localStorage.setItem('dio-theme', 'dark') } catch (e) {}
             }
         }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -40,7 +40,7 @@ export default {
     script: [
       {
         hid: 'theme-init',
-        innerHTML: `(function(){try{var t=localStorage.getItem('dio-theme');if(t==='light'){document.documentElement.setAttribute('data-theme','light');}}catch(e){}})();`,
+        innerHTML: `(function(){try{var t=localStorage.getItem('dio-theme');if(t==='dark'){document.documentElement.setAttribute('data-theme','dark');}}catch(e){}})();`,
         type: 'text/javascript'
       },
       { src: 'https://www.googletagmanager.com/gtag/js?id=G-LLY1T4DZX7', async: true },


### PR DESCRIPTION
Follow-up to #29: Policymaker now **defaults to light mode**, with dark as the opt-in toggle (persisted).

- `_app-theme.css`: light token values are the base `:root`; dark moved to `[data-theme="dark"]`.
- Pre-paint theme-init script applies `data-theme=dark` only when the stored pref is `dark` (no FOUC).
- Toggle: light removes the attr (default), dark sets `data-theme=dark`.

Verified locally: fresh load (no pref) → light; toggle → dark + persists; reload with stored dark → dark pre-paint; zero new console errors.