### PR TITLE
feat(design): remove theme switcher, light-only

### DIFF
--- a/assets/css/_app-theme.css
+++ b/assets/css/_app-theme.css
@@ -1,9 +1,8 @@
 /* ─────────────────────────────────────────────────────────────
- * disclose.io — APP Design System (Policymaker: LIGHT-default)
- * Tokens derived from lookup.disclose.io's app language.
- * Policymaker defaults to LIGHT (:root); dark is opt-in via
- * [data-theme="dark"] on <html>. (lookup itself is dark-default;
- * this app deliberately leads with light.)
+ * disclose.io — APP Design System (Policymaker: light-only)
+ * Tokens derived from lookup.disclose.io's app language, applied
+ * as a single light theme (no theme switcher). (lookup itself is
+ * dark-default; this app leads with — and stays — light.)
  * ───────────────────────────────────────────────────────────── */
 
 @import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&family=JetBrains+Mono:wght@400;500&display=swap');
@@ -45,30 +44,4 @@
   --shadow:    0 1px 3px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.04);
   --shadow-lg: 0 4px 12px rgba(0, 0, 0, 0.10), 0 2px 4px rgba(0, 0, 0, 0.06);
   --transition: 0.15s ease;
-}
-
-/* ── Dark theme (opt-in via toggle) ──────────────────────────── */
-[data-theme="dark"] {
-  --bg:            #0a0a0f;
-  --surface:       #12121a;
-  --surface-2:     #1a1a25;
-  --surface-3:     #222230;
-  --border:        #2a2a35;
-  --border-light:  #35354a;
-
-  --text:          #e4e4e8;
-  --text-heading:  #f4f4f5;
-  --text-muted:    #8888a0;
-  --text-dim:      #5a5a70;
-
-  --accent:        #7c5cfc;
-  --accent-hover:  #9580ff;
-  --accent-dim:    rgba(124, 92, 252, 0.12);
-
-  --high-bg:     rgba(34, 197, 94, 0.10);
-  --high-border: rgba(34, 197, 94, 0.25);
-  --medium-bg:   rgba(234, 179, 8, 0.10);
-  --error-bg:    rgba(239, 68, 68, 0.10);
-  --shadow:      0 1px 3px rgba(0, 0, 0, 0.30), 0 1px 2px rgba(0, 0, 0, 0.20);
-  --shadow-lg:   0 4px 12px rgba(0, 0, 0, 0.40), 0 2px 4px rgba(0, 0, 0, 0.30);
 }

--- a/layouts/policymaker.vue
+++ b/layouts/policymaker.vue
@@ -5,12 +5,6 @@
                 <img src="@/assets/images/logo-disclose-type.svg">
             </NuxtLink>
 
-            <button class="theme-toggle" type="button" @click="toggleTheme"
-                :title="isLight ? 'Switch to dark theme' : 'Switch to light theme'"
-                aria-label="Toggle light/dark theme">
-                <span v-if="isLight">☀</span><span v-else>☾</span>
-            </button>
-
             <nav>
                 <progress-steps orientation="vertical" :steps="navSteps">
                 </Progress-Steps>
@@ -41,9 +35,7 @@ export default Vue.extend({
   components: { ProgressSteps },
     
     data() {
-        return {
-            isLight: false
-        }
+        return {}
     },
 
     head() {
@@ -61,27 +53,10 @@ export default Vue.extend({
     },
 
     mounted() {
-        const vm = this as any
-        vm.isLight = document.documentElement.getAttribute('data-theme') !== 'dark'
         this.$nextTick(() => {
             store.dispatch('policymaker/fetchLanguages')
             store.dispatch('policymaker/syncStepFromRoute', this.$route.fullPath)
         })
-    },
-
-    methods: {
-        toggleTheme(): void {
-            const vm = this as any
-            vm.isLight = !vm.isLight
-            const root = document.documentElement
-            if (vm.isLight) {
-                root.removeAttribute('data-theme')
-                try { localStorage.setItem('dio-theme', 'light') } catch (e) {}
-            } else {
-                root.setAttribute('data-theme', 'dark')
-                try { localStorage.setItem('dio-theme', 'dark') } catch (e) {}
-            }
-        }
     },
 
     computed: {
@@ -122,24 +97,6 @@ header {
 
     nav {
         @apply mt-12 mb-12 hidden lg:block;
-    }
-
-    .theme-toggle {
-        @apply flex items-center justify-center cursor-pointer;
-        width: 36px;
-        height: 36px;
-        margin-left: auto;
-        background: var(--surface-2);
-        border: 1px solid var(--border);
-        border-radius: var(--radius);
-        color: var(--text-muted);
-        font-size: 16px;
-        transition: all var(--transition);
-
-        &:hover {
-            border-color: var(--border-light);
-            color: var(--text);
-        }
     }
 }
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -38,11 +38,6 @@ export default {
       { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&family=JetBrains+Mono:wght@400;500&display=swap' }
     ],
     script: [
-      {
-        hid: 'theme-init',
-        innerHTML: `(function(){try{var t=localStorage.getItem('dio-theme');if(t==='dark'){document.documentElement.setAttribute('data-theme','dark');}}catch(e){}})();`,
-        type: 'text/javascript'
-      },
       { src: 'https://www.googletagmanager.com/gtag/js?id=G-LLY1T4DZX7', async: true },
       {
         hid: 'gtag-init',


### PR DESCRIPTION
Follow-up to #30: removes the light/dark toggle entirely — Policymaker is now **light-only**.

- Removed the theme-toggle button + `toggleTheme`/`isLight` logic from the layout.
- Removed the pre-paint theme-init script from `nuxt.config`.
- Dropped the now-unreachable `[data-theme="dark"]` token block; the light `:root` is the only theme.

Verified locally: no toggle button in the DOM, `data-theme:null`, light render, clean compile, no dangling refs.