### PR TITLE
Render Policymaker landing content and outcome events

### DIFF
--- a/components/DioTermPreview/DioTermPreview.vue
+++ b/components/DioTermPreview/DioTermPreview.vue
@@ -134,6 +134,10 @@ export default Vue.extend({
                     artifact: event.eventCategory,
                     format: (download.trackingEvent || {}).eventLabel
                 })
+                gtag('event', 'artifact_download', {
+                    artifact: event.eventCategory,
+                    format: (download.trackingEvent || {}).eventLabel
+                })
             }
         }
     },

--- a/layouts/policymaker.vue
+++ b/layouts/policymaker.vue
@@ -46,7 +46,7 @@ export default Vue.extend({
           {
             hid: 'description',
             name: 'description',
-            content: 'Disclose.io policymaker'
+            content: 'Generate a vulnerability disclosure policy, safe-harbor clause, security.txt file, and DNS Security TXT record with the free disclose.io Policymaker.'
           }
         ]
       }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -45,7 +45,17 @@ export default {
           window.dataLayer = window.dataLayer || [];
           function gtag(){dataLayer.push(arguments);}
           gtag('js', new Date());
-          gtag('config', 'G-LLY1T4DZX7');
+          gtag('config', 'G-LLY1T4DZX7', {
+            linker: {
+              domains: [
+                'disclose.io',
+                'directory.disclose.io',
+                'lookup.disclose.io',
+                'policymaker.disclose.io',
+                'vault.disclose.io'
+              ]
+            }
+          });
         `,
         type: 'text/javascript',
         charset: 'utf-8'

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,8 +1,124 @@
+<template>
+    <article class="policymaker-landing">
+        <header class="landing-hero">
+            <p class="landing-eyebrow">Free, open-source vulnerability disclosure tooling</p>
+            <h1>Generate a vulnerability disclosure policy, safe harbor, and security.txt</h1>
+            <p class="landing-lede">
+                Policymaker turns a few details about your organization into a complete disclosure setup: a customizable VDP, optional coordinated-disclosure timeline, standalone safe-harbor language, an RFC 9116 security.txt file, and a DNS Security TXT record.
+            </p>
+            <div class="dio__action-bar">
+                <DioButton @click="begin">Build your policy</DioButton>
+            </div>
+        </header>
+
+        <section class="landing-summary" aria-labelledby="what-you-get">
+            <h2 id="what-you-get">What Policymaker produces</h2>
+            <ul>
+                <li><strong>Vulnerability Disclosure Policy:</strong> a complete policy for a new or replacement program.</li>
+                <li><strong>Safe Harbor:</strong> standardized language that can be added to an existing policy.</li>
+                <li><strong>security.txt:</strong> an RFC 9116 file that directs researchers to the correct reporting channel.</li>
+                <li><strong>DNS Security TXT:</strong> a DNS record that publishes security-contact information.</li>
+            </ul>
+            <p>
+                The generated language comes from the disclose.io Framework's canonical, publicly reviewed terms. Policymaker is a starting point for implementation and does not provide legal advice.
+            </p>
+        </section>
+
+        <nuxt-content :document="content"></nuxt-content>
+
+        <div class="dio__action-bar">
+            <DioButton @click="begin">Begin</DioButton>
+        </div>
+    </article>
+</template>
+
 <script lang="ts">
 import Vue from 'vue'
+import nav from '~/mixins/nav'
+import DioButton from '~/components/DioButton/DioButton.vue'
+
 export default Vue.extend({
-    middleware({redirect}) {
-        return redirect("/policymaker")
+    layout: 'policymaker',
+    components: { DioButton },
+    mixins: [nav],
+
+    async asyncData({ $content }) {
+        const content = await $content('policymaker/introduction').fetch()
+        return { content }
+    },
+
+    head() {
+        return {
+            title: 'Vulnerability Disclosure Policy Generator | disclose.io',
+            link: [
+                { hid: 'canonical', rel: 'canonical', href: 'https://policymaker.disclose.io/' }
+            ],
+            meta: [
+                {
+                    hid: 'description',
+                    name: 'description',
+                    content: 'Generate a vulnerability disclosure policy, safe-harbor clause, security.txt file, and DNS Security TXT record with the free disclose.io Policymaker.'
+                }
+            ]
+        }
+    },
+
+    methods: {
+        begin(): void {
+            const gtag = (window as any).gtag
+            if (typeof gtag === 'function') {
+                gtag('event', 'policymaker_start', { entry_point: 'landing_page' })
+            }
+            ;(this as any).goto(2)
+        }
     }
 })
 </script>
+
+<style lang="postcss">
+.policymaker-landing {
+    @apply max-w-4xl;
+}
+
+.landing-hero {
+    @apply py-4 lg:py-8 mb-12 border-b border-gray-300;
+
+    h1 {
+        @apply text-2xl lg:text-3xl font-bold mt-3;
+        max-width: 22ch;
+    }
+}
+
+.landing-eyebrow {
+    @apply text-sm font-medium text-purple-800;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.landing-lede {
+    @apply text-base lg:text-lg mt-6;
+    color: var(--text-muted);
+    max-width: 68ch;
+}
+
+.landing-summary {
+    @apply bg-white border border-gray-300 rounded-md p-4 lg:p-7 mb-12;
+
+    h2 {
+        @apply text-lg lg:text-2xl font-bold mb-4;
+    }
+
+    ul {
+        @apply list-disc list-outside pl-6;
+    }
+
+    li {
+        @apply mb-2;
+    }
+
+    p {
+        @apply mt-6 text-sm;
+        color: var(--text-muted);
+    }
+}
+</style>

--- a/pages/policymaker/download.vue
+++ b/pages/policymaker/download.vue
@@ -36,6 +36,15 @@ export default Vue.extend({
             vm.goto(1)
         } else {
             store.dispatch('policymaker/fetchTerms').then(() => {
+                if (process.client) {
+                    const gtag = (window as any).gtag
+                    if (typeof gtag === 'function') {
+                        gtag('event', 'policy_generated', {
+                            artifact: 'vulnerability_disclosure_policy',
+                            cvd_enabled: (this.configuration as any).cvdTimelineDays > 0
+                        })
+                    }
+                }
                 this.$router.push(this.sections[0].route)
             })
         }

--- a/pages/policymaker/download/dnssecuritytxt.vue
+++ b/pages/policymaker/download/dnssecuritytxt.vue
@@ -27,9 +27,15 @@ export default Vue.extend({
         }
     },
 
+    mounted() {
+        const gtag = (window as any).gtag
+        if (typeof gtag === 'function') {
+            gtag('event', 'security_txt_generated', { variant: 'dns_record' })
+        }
+    },
+
     computed: {
         configuration: () => store.getters['policymaker/getConfiguration'],
     }
 })
 </script>
-

--- a/pages/policymaker/download/securitytxt.vue
+++ b/pages/policymaker/download/securitytxt.vue
@@ -57,7 +57,14 @@ export default Vue.extend({
     },
 
     created() {
-        store.dispatch('policymaker/fetchSecurityTxt')
+        store.dispatch('policymaker/fetchSecurityTxt').then(() => {
+            if (process.client) {
+                const gtag = (window as any).gtag
+                if (typeof gtag === 'function') {
+                    gtag('event', 'security_txt_generated', { variant: 'rfc9116_file' })
+                }
+            }
+        })
     },
 
     computed: {

--- a/pages/policymaker/introduction.vue
+++ b/pages/policymaker/introduction.vue
@@ -7,7 +7,7 @@
         <nuxt-content :document="content"></nuxt-content>
 
         <div class="dio__action-bar">
-            <DioButton @click="goto(2)">Begin</DioButton>
+            <DioButton @click="begin">Begin</DioButton>
         </div>
     </div>
 </template>
@@ -39,6 +39,16 @@ export default Vue.extend({
         const content = await $content(route.fullPath).fetch()
         return {
             content
+        }
+    },
+
+    methods: {
+        begin(): void {
+            const gtag = (window as any).gtag
+            if (typeof gtag === 'function') {
+                gtag('event', 'policymaker_start', { entry_point: 'wizard_introduction' })
+            }
+            ;(this as any).goto(2)
         }
     }
 })


### PR DESCRIPTION
## Summary

- replace the JavaScript-only root redirect with a statically generated landing page and canonical URL
- explain the VDP, safe-harbor, security.txt, and DNS outputs in server-rendered HTML
- track Policymaker starts, generated policy/security.txt outcomes, and artifact downloads
- enable cross-domain linking across disclose.io tools

## Verification

- static generation passed on the repository-pinned Node 16 toolchain
- verified `dist/index.html` contains the title, canonical, H1, substantive copy, and JSON-LD before hydration
